### PR TITLE
Fix action notfound

### DIFF
--- a/lib/Lib/Core/App.js
+++ b/lib/Lib/Core/App.js
@@ -63,6 +63,8 @@ App.getCallController = function(http){
     action: action
   }, true);
   if (instance) {
+    http.group = group;
+    http.controller = controller;
     http.action = action;
   }
   return instance;


### PR DESCRIPTION
没有对group controller action按照call_controller值进行赋值， 导致后面还是按照之前的action名称获取对应action函数，返回值为undefined，引起接下来后面的toString调用错误. 在获取模板名称时也错误的沿用了之前的group 和 controller名称。
