### PR TITLE
修复设置自定义数据库名未能生效的问题

### DIFF
--- a/lib/Lib/Core/Model.js
+++ b/lib/Lib/Core/Model.js
@@ -88,6 +88,12 @@ var Model = module.exports = Class(function(){
         config = {db_prefix: config};
       }
       this.config = config || '';
+
+      //如果Model设置了实际数据库名，则需要将数据库名进行设置
+      if(this.dbName) {
+        this.config.db_name = this.dbName;
+      }
+      
       //数据表前缀
       if (this.config.db_prefix) {
         this.tablePrefix = this.config.db_prefix;


### PR DESCRIPTION
文档中有说明允许在Model定义里自定义数据库名，但不能生效

``` javascript
//自定义属性的模型
module.exports = Model(function(){
    return {
        dbName: 'test2',
        trueTableName: 'think2_users'
    }
})
```

此PR修复此问题。
