### PR TITLE
update parseSql

### DIFF
--- a/src/adapter/db/_parse.js
+++ b/src/adapter/db/_parse.js
@@ -597,7 +597,7 @@ export default class extends think.base {
         return this['parse' + ucfirst](options[type] || '', options);
       }
       return a;
-    }).replace(/\s__([A-Z_-]+)__\s/g, (a, b) => {
+    }).replace(/\s__([A-Z_-]+)__\s?/g, (a, b) => {
       return ' `' + this.config.prefix + b.toLowerCase() + '` ';
     });
   }


### PR DESCRIPTION
this.parseSql("SELECT * FROM __TEST__"); 这种情况没法解析
/\s__([A-Z_-]+)__\s/g  改成  /\s__([A-Z_-]+)__\s?/g