### PR TITLE
x-forwarded-for数组中ip有空格问题

### DIFF
--- a/src/core/http.js
+++ b/src/core/http.js
@@ -419,7 +419,7 @@ export default class {
     let localIP = '127.0.0.1';
     if (proxy) {
       if (forward) {
-        return (this.headers['x-forwarded-for'] || '').split(',').filter(item => {
+        return (this.headers['x-forwarded-for'] || '').split(/\,[\s]*/).filter(item => {
           item = item.trim();
           if (think.isIP(item)) {
             return item;

--- a/src/core/http.js
+++ b/src/core/http.js
@@ -419,7 +419,7 @@ export default class {
     let localIP = '127.0.0.1';
     if (proxy) {
       if (forward) {
-        return (this.headers['x-forwarded-for'] || '').split(/\,[\s]*/).filter(item => {
+        return (this.headers['x-forwarded-for'] || '').split(/\s*,\s*/).filter(item => {
           item = item.trim();
           if (think.isIP(item)) {
             return item;


### PR DESCRIPTION
搞think-log打印日志过程中发现http.ip(true);出来的日志的ip含有空格造成了切割日志时的错误；
http的get ip如果获取x-forwarded-for内的值为数组， 应该去除空格吧；
````javascript
if (proxy) {
      if (forward) {
        return (this.headers['x-forwarded-for'] || '').split(,).filter(item => {
          item = item.trim();
          if (think.isIP(item)) {
            return item;
          }
        });
      }
      userIP = this.headers['x-real-ip'];
    }
````
修正为
````
if (proxy) {
      if (forward) {
        return (this.headers['x-forwarded-for'] || '').split(/\,[\s]*/).filter(item => {
          item = item.trim();
          if (think.isIP(item)) {
            return item;
          }
        });
      }
      userIP = this.headers['x-real-ip'];
    }
`````
还有就是test中大量用了assert.equal
如assert.equal(http.ip(true), '10.0.0.1'); equal相当于== ，用来测试[10.0.0.1]=='10.0.0.1'感觉也不合理