### PR TITLE
多语言支持仅有语种的语言名

### DIFF
--- a/src/core/think.js
+++ b/src/core/think.js
@@ -839,13 +839,13 @@ think.locale = function(key, ...data) {
     locales = this.config(think.dirname.locale);
   }
   let langLocale = locales[lang] || {};
-  let countryLangLocale = locales[lang.split('-')[0]] || {};
+  let backupLangLocale = locales[lang.split('-')[0]] || {};
   let defaultLangLocale = locales[defaultLang] || {};
   if(!key){
     return think.isEmpty(langLocale) ? defaultLangLocale : langLocale;
   }
   let enLocale = locales.en || {};
-  let value = langLocale[key] || countryLangLocale[key] || defaultLangLocale[key] || enLocale[key] || key;
+  let value = langLocale[key] || backupLangLocale[key] || defaultLangLocale[key] || enLocale[key] || key;
   if(!think.isString(value)){
     return value;
   }

--- a/src/core/think.js
+++ b/src/core/think.js
@@ -839,12 +839,13 @@ think.locale = function(key, ...data) {
     locales = this.config(think.dirname.locale);
   }
   let langLocale = locales[lang] || {};
+  let countryLangLocale = locales[lang.split('-')[0]] || {};
   let defaultLangLocale = locales[defaultLang] || {};
   if(!key){
     return think.isEmpty(langLocale) ? defaultLangLocale : langLocale;
   }
   let enLocale = locales.en || {};
-  let value = langLocale[key] || defaultLangLocale[key] || enLocale[key] || key;
+  let value = langLocale[key] || countryLangLocale[key] || defaultLangLocale[key] || enLocale[key] || key;
   if(!think.isString(value)){
     return value;
   }


### PR DESCRIPTION
当前的 ThinkJS（2.2）中的多语言文件必须要按照完整的语言名来命名，如 `zh-cn`、`en-us`等，但其实很多情况下我们只明确这个语言文件是用于英语的，无论是美式英语还是英式英语，或加拿大的英语，这时候 `en-us` 就显得太过局限性。

一个标准的由中划线分隔的语言码，如 `zh-ch` ，前半部分指语言名，后半部分指国家或地区。而中文又分为简体中文和繁体中文，繁体中文又有台湾、香港、新加坡等不同地区。如果文件名必须准确按照语言名定义就会出现 `zh-tw`, `zh-hk` 等内容相同的不同语言。

所以我对这部分代码作出一个小的改变，先去按照准确的语言名查找（如 `zh-tw`），如果找不到这个语言就尝试后备的仅查找语言名（`zh`），两者均找不到时再使用默认语言（`en`）。

如此一来 `locale` 目录里的文件结构可能是这样：

```
/ locale
  - en.js   // 默认语言
  - en-us.js  // 仅用于美式英语
  - zh.js   // 默认的中文
  - zh-cn.js   // 仅用于简单中文，即所有的繁体中文都会在 zh.js 中查找
  - ...
```