### PR TITLE
输出静态文件增加设置 header 的功能

### DIFF
--- a/src/middleware/check_resource.js
+++ b/src/middleware/check_resource.js
@@ -40,6 +40,11 @@ export default class extends think.middleware.base {
       if(cors){
         this.http.header('Access-Control-Allow-Origin', typeof cors === 'string' ? cors : '*');
       }
+      // extend resource headers
+      const resourceHeaders = this.config('resource_headers') || {};
+      for (let header in resourceHeaders) {
+        this.http.header(header, resourceHeaders[header]);
+      }
       return file;
     }else{
       return true;


### PR DESCRIPTION
在设置里面增加一项 `resource_headers` 配置，用于设置输出通过 NodeJS 输出静态文件时的 Header。如下：

config.js

```js
export default {
  resource_on: true,
  resource_headers: {
    'Cache-Control': 'public, max-age=31536000'
  }
}
```

虽然一般来说是不建议通过 NodeJS 输出静态文件的，在考虑在某些场景下（如直接把 Thinkjs 的代码打包到 Docker 中运行）时 Nginx 是访问不到站点的静态文件目录的，这时候就只能通过反向代理的方式访问静态资源文件。

这种情况下，使用代理返回静态文件内容，配合 Nginx 的代理缓存，将会是很巧妙的组合，完全兼顾性能及 Docker 部署的便利性。但 Nginx 的代理缓存要求输出 Header `Cache-Control: public`，所以我在这里增加了这么一项配置用于设置输出的资源文件的 Header。

其它地方的用途有待发掘，不过貌似可以取代 `resource_cors` 设置了。