### PR TITLE
解决  think.parallelLimit 行为古怪(应该是bug),   以及与文档不一致的问题.

### DIFF
--- a/src/core/think.js
+++ b/src/core/think.js
@@ -1040,9 +1040,6 @@ think.parallelLimit = (key, data, callback, options = {}) => {
   }
   
   let flag = !think.isArray(data) || options.array;
-  if(!flag){
-    key = '';
-  }
 
   //get parallel limit class
   let Limit = thinkCache(thinkCache.COLLECTION, 'limit');
@@ -1055,7 +1052,7 @@ think.parallelLimit = (key, data, callback, options = {}) => {
   if(key){
     instance = thinkCache(thinkCache.LIMIT, key);
     if(!instance){
-      instance = new Limit(options.limit, callback);
+      instance = new Limit(options.limit);
       thinkCache(thinkCache.LIMIT, key, instance);
     }
   }else{
@@ -1063,7 +1060,7 @@ think.parallelLimit = (key, data, callback, options = {}) => {
   }
 
   if(flag){
-    return instance.add(data);
+    return instance.add(data, key && callback);
   }
-  return instance.addMany(data, options.ignoreError);
+  return instance.addMany(data, key && callback, options.ignoreError);
 };

--- a/src/core/think.js
+++ b/src/core/think.js
@@ -1028,8 +1028,12 @@ think.parallelLimit = (key, data, callback, options = {}) => {
   if(!think.isString(key) || think.isFunction(data)){
     options = callback || {};
     callback = data;
-    data = key;
-    key = '';
+    if(think.isString(key)){
+      data = undefined;
+    }else{
+      data = key;
+      key = '';
+    }
   }
   if(!think.isFunction(callback)){
     options = callback || {};
@@ -1049,6 +1053,9 @@ think.parallelLimit = (key, data, callback, options = {}) => {
   }
 
   let instance;
+  if(think.isFunction(data)){
+    key = '__parallelLimit';
+  }
   if(key){
     instance = thinkCache(thinkCache.LIMIT, key);
     if(!instance){

--- a/src/util/parallel_limit.js
+++ b/src/util/parallel_limit.js
@@ -25,9 +25,10 @@ export default class extends think.base {
    * add item data
    * @param {data} item []
    */
-  add(item){
+  add(item, callback){
     let deferred = think.defer();
     deferred.data = item;
+    deferred.callback = callback;
     this.deferreds.push(deferred);
     this.run();
     return deferred.promise;
@@ -36,12 +37,12 @@ export default class extends think.base {
    * add many data once
    * @param {Array} dataList [data array]
    */
-  addMany(dataList, ignoreError){
+  addMany(dataList, callback, ignoreError){
     if (think.isEmpty(dataList)) {
       return Promise.resolve();
     }
     let promises = dataList.map(item => {
-      let promise = this.add(item);
+      let promise = this.add(item, callback);
       return ignoreError ? promise.catch(() => {}) : promise;
     });
     return Promise.all(promises);
@@ -69,7 +70,7 @@ export default class extends think.base {
     }
     this.doing++;
     let item = this.deferreds[this.index++];
-    let callback = think.isFunction(item.data) ? item.data : this.callback;
+    let callback = think.isFunction(item.data) ? item.data : item.callback || this.callback;
     if (!think.isFunction(callback)) {
       throw new Error('data item or callback must be a function');
     }

--- a/test/core/think.js
+++ b/test/core/think.js
@@ -2618,11 +2618,11 @@ describe('core/think.js', function(){
       done();
     })
   })
-  it('think.parallelLimit key is not set', function(done){
-    think.parallelLimit('data', function(name){
+  it('think.parallelLimit data is not set', function(done){
+    think.parallelLimit('key', function(name){
       return name;
     }).then(function(data){
-      assert.equal(data, 'data');
+      assert.equal(data, undefined);
       done();
     })
   })

--- a/test/core/think.js
+++ b/test/core/think.js
@@ -2592,6 +2592,15 @@ describe('core/think.js', function(){
     })
   })
 
+  it('think.parallelLimit normal again', function(done){
+    think.parallelLimit('key', 'name', function(name){
+      return 'again';
+    }).then(function(data){
+      assert.equal(data, 'again');
+      done();
+    })
+  })
+
   it('think.parallelLimit normal, is not function', function(done){
     try{
       think.parallelLimit('keywwww', 'name', {limit: 10});


### PR DESCRIPTION
1. 解决 当使用相同 key 多次调用  think.parallelLimit, 总是执行第一次传递的 callback, 而导致不能得到预期结果.   
bug如下:
```js
think.parallelLimit('key', 'name', function(name){
      return name +'1';
    }).then(function(data){
       //第一次调用 正常 data  ==  'name1'
    })
 think.parallelLimit('key', 'name', function(name){
      return 'name'+ '2';
    }).then(function(data){
       //第二次调用  data 并不是 name2  而是name1  
    })
```

2. 解决 think.parallel_limit 与文档意图不一致的行为  …
 https://thinkjs.org/zh-cn/doc/2.2/api_think.html#toc-0a1
 并不能达到同时执行数量限制的作用. 

3. 解决只有一个参数 callback 的情况下没有起到任何限制作用的bug
