### PR TITLE
websocket

### DIFF
--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Base from './base.js';
-import Url from 'url';
+import url from 'url';
 /**
  * websocket adapter for socket.io
  */
@@ -73,7 +73,7 @@ export default class extends Base {
       //open connection
       if(open){
         let request = socket.request;
-        let urlParse = Url.parse(request.url);
+        let urlParse = url.parse(request.url);
         open = `${open}${urlParse.search}`;
         this.message(open, undefined, socket);
       }

--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -72,9 +72,12 @@ export default class extends Base {
 
       //open connection
       if(open){
+
         let request = socket.request;
-        let urlParse = url.parse(request.url);
-        open = `${open}${urlParse.search}`;
+        if(request && request.url) {
+          let urlParse = url.parse(request.url);
+          open = `${open}${urlParse.search}`;
+        }
         this.message(open, undefined, socket);
       }
       //listen disonnection event

--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -123,6 +123,9 @@ export default class extends Base {
    */
   async message(url, data, socket){
     let request = socket.request;
+    if(url[0] !== '/'){
+        url = `/${url}`;
+    }
     request.url = url;
     let http;
     //socket.io c++ client发过来的requet没有res

--- a/src/adapter/websocket/socket.io.js
+++ b/src/adapter/websocket/socket.io.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Base from './base.js';
+import Url from 'url';
 /**
  * websocket adapter for socket.io
  */
@@ -71,6 +72,9 @@ export default class extends Base {
 
       //open connection
       if(open){
+        let request = socket.request;
+        let urlParse = Url.parse(request.url);
+        open = `${open}${urlParse.search}`;
         this.message(open, undefined, socket);
       }
       //listen disonnection event
@@ -119,9 +123,6 @@ export default class extends Base {
    */
   async message(url, data, socket){
     let request = socket.request;
-    if(url[0] !== '/'){
-      url = `/${url}`;
-    }
     request.url = url;
     let http;
     //socket.io c++ client发过来的requet没有res


### PR DESCRIPTION
在websocket open的时候 会在URL上附带参数 以便于 对socket 进行鉴权和管理，但是之前 url把config配上的直接输出了到request.url上， 没有附加search的内容。 以至于在controller里 用this.get 获取不到本应该附属在链接上的参数。