### PR TITLE
添加content-type校验

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "co": "4.6.0",
     "colors": "1.1.2",
     "commander": "2.9.0",
-    "content-type": "^1.0.2",
     "ejs": "2.4.1",
     "mime": "1.3.4",
     "multiparty": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -42,17 +42,18 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "ejs": "2.4.1",
-    "multiparty": "4.1.2",
-    "mime": "1.3.4",
-    "mysql": "2.11.1",
-    "thinkit": "4.10.0",
     "babel-runtime": "6.6.1",
     "bluebird": "3.3.5",
     "co": "4.6.0",
     "colors": "1.1.2",
-    "validator": "4.2.0",
-    "commander": "2.9.0"
+    "commander": "2.9.0",
+    "content-type": "^1.0.2",
+    "ejs": "2.4.1",
+    "mime": "1.3.4",
+    "multiparty": "4.1.2",
+    "mysql": "2.11.1",
+    "thinkit": "4.10.0",
+    "validator": "4.2.0"
   },
   "devDependencies": {
     "mocha": "1.20.1",

--- a/src/config/locale/en.js
+++ b/src/config/locale/en.js
@@ -31,6 +31,7 @@ export default {
   SERVICE_UNAVAILABLE: 'Service Unavailable',
   URL_HAS_UPPERCASE: 'url has uppercases(%s), auto convert to lowercase.',
   METHOD_NOT_ALLOWED: 'request method is not allowed.',
+  UNSUPPORTED_MEDIA_TYPE : 'request Content-Type or Content-Encoding is not allowed.',
   METHOD_NOT_EXIST: 'method %s not exist',
 
   validate_required: '{name} can not be blank',

--- a/src/core/http.js
+++ b/src/core/http.js
@@ -184,9 +184,9 @@ export default class {
    * @return {Promise} []
    */
   async parsePayload(){
-    if(this.hasPayload()){
-      await think.hook('payload_parse', this);
+    if (this.hasPayload()) {
       await think.hook('payload_validate', this);
+      await think.hook('payload_parse', this);
     }
   }
   

--- a/src/core/http.js
+++ b/src/core/http.js
@@ -185,8 +185,8 @@ export default class {
    */
   async parsePayload(){
     if (this.hasPayload()) {
-      await think.hook('payload_validate', this);
       await think.hook('payload_parse', this);
+      await think.hook('payload_validate', this);
     }
   }
   

--- a/src/logic/base.js
+++ b/src/logic/base.js
@@ -154,18 +154,23 @@ export default class extends think.controller.base {
    */
   __after(){
     let error = this.config('error');
-    
-    //check request method
-    let allowMethods = this.allowMethods;
-    if(!think.isEmpty(allowMethods)){
-      if(think.isString(allowMethods)){
-        allowMethods = allowMethods.split(',');
-      }
-      let method = this.http.method.toLowerCase();
-      if(allowMethods.indexOf(method) === -1){
-        return this.fail(error.validate_errno, this.locale('METHOD_NOT_ALLOWED')); 
+
+    const checkRequest = (expects, actual, errmsg) => {
+      if (!think.isEmpty(expects)) {
+        if (think.isString(expects)) {
+          expects = expects.split(',');
+        }
+        if (expects.indexOf(actual) === -1) {
+          return this.fail(error.validate_errno, errmsg);
+        }
       }
     }
+
+    //check request method
+    checkRequest(this.allowMethods, this.http.method.toLowerCase(), this.locale('METHOD_NOT_ALLOWED'));
+
+    //check request content-type
+    checkRequest(this.allowContentTypes, this.http.req.headers['content-type'], this.locale('UNSUPPORTED_MEDIA_TYPE'));
 
     //check rules
     if(think.isEmpty(this.rules) || this._validateInvoked){

--- a/src/middleware/validate_payload.js
+++ b/src/middleware/validate_payload.js
@@ -1,5 +1,4 @@
 'use strict';
-import contentType from 'content-type'
 /**
  * validate post data
  * @type {}
@@ -25,14 +24,6 @@ export default class extends think.middleware.base {
         http.end();
         return think.prevent();
       }
-    }
-    try {
-      contentType.parse(http.req.headers['content-type'])
-    } catch (e) {
-      think.log(`inValid content-type ${http.req.headers['content-type']}`)
-      http.res.statusCode = 400;
-      http.end(`${e}`);
-      return think.prevent();
     }
   }
 }

--- a/src/middleware/validate_payload.js
+++ b/src/middleware/validate_payload.js
@@ -1,5 +1,5 @@
 'use strict';
-
+import contentType from 'content-type'
 /**
  * validate post data
  * @type {}
@@ -25,6 +25,14 @@ export default class extends think.middleware.base {
         http.end();
         return think.prevent();
       }
+    }
+    try {
+      contentType.parse(http.req.headers['content-type'])
+    } catch (e) {
+      think.log(`inValid content-type ${http.req.headers['content-type']}`)
+      http.res.statusCode = 400;
+      http.end(`${e}`);
+      return think.prevent();
     }
   }
 }

--- a/test/logic/base.js
+++ b/test/logic/base.js
@@ -982,4 +982,40 @@ describe('logic/base', function(){
       done();
     })
   })
+  it('__after, has allowMethods', function (done) {
+    getInstance({}, {
+      _config: think.config(),
+      _post: {
+        name: '',
+        suredy: '2014-11-10'
+      },
+        method: 'PUT'
+    }).then(function (instance) {
+        instance.allowMethods = 'get,post'
+        instance.fail = function (errno, errmsg) {
+          assert.equal(errno, 1001);
+          done();
+        }
+        instance.__after()
+      })
+  })
+  it('__after, has allowContentTypes', function (done) {
+    getInstance({}, {
+      _config: think.config(),
+      _post: {
+        name: '',
+        suredy: '2014-11-10'
+      },
+      headers: {
+        'content-type' : 'application/x-www-form-urlencoded'
+      }
+      }).then(function (instance) {
+        instance.allowContentTypes = 'application/json,application/json;charset=utf-8'
+        instance.fail = function (errno, errmsg) {
+          assert.equal(errno, 1001);
+          done();
+        }
+        instance.__after()
+      })
+  })
 })

--- a/test/middleware/validate_payload.js
+++ b/test/middleware/validate_payload.js
@@ -17,6 +17,7 @@ function getHttp(config, options){
   think.APP_PATH = path.dirname(__dirname) + think.sep + 'testApp';
   var req = think.extend({}, _http.req);
   req.readable = true;
+  req.headers['content-type'] = 'application/json'
 
   var res = think.extend({}, _http.res);
   return think.http(req, res).then(function(http){


### PR DESCRIPTION
接口调用时发生content-type错误导致_post返回空对象，是不是可以在框架内做更友好的提示