### PR TITLE
Couldn't find preset "es2015"

### DIFF
--- a/src/util/watch_compile.js
+++ b/src/util/watch_compile.js
@@ -144,7 +144,7 @@ export default class {
     let babel = require('babel-core');
     let data = babel.transform(content, {
       filename: file,
-      presets: [].concat(this.options.presets || [['es2015', {'loose': true}], 'stage-1']),
+      presets: [].concat(this.options.presets || ["babel-preset-es2015"].map(require.resolve)),
       plugins: [].concat(this.options.plugins || ['transform-runtime']),
       sourceMaps: true,
       sourceFileName: relativePath


### PR DESCRIPTION
In babel 1.2.4, es2015 will error "Couldn't find preset "es2015" relative to directory"
and need babel-preset-es2015 in package.json。