### PR TITLE
Fix usage after upgrade pg

### DIFF
--- a/src/adapter/socket/postgresql.js
+++ b/src/adapter/socket/postgresql.js
@@ -38,17 +38,8 @@ export default class extends Base {
     pg.defaults.poolIdleTimeout = this.config.poolIdleTimeout * 1000 || 8 * 60 * 60 * 1000;
 
     //when has error, close connection
-    pg.on('error', () => {
-      this.close();
-    });
-    pg.on('end', () => {
-      this.close();
-    });
-    pg.on('close', () => {
-      this.close();
-    });
-    this.pg = pg;
-    return pg;
+    this.pg = pg.Pool;
+    return pg.Pool;
   }
   /**
    * get connection
@@ -58,13 +49,15 @@ export default class extends Base {
     if(this.connection){
       return this.connection;
     }
-    let pg = await this.getPG();
+    let Pool = await this.getPG();
+    const pool = new Pool(this.config);
+
     let config = this.config;
     let connectionStr = `postgres://${config.user}:${config.password}@${config.host}:${config.port}/${config.database}`;
 
     return think.await(connectionStr, () => {
       let deferred = think.defer();
-      pg.connect(this.config, (err, client, done) => {
+      pool.connect((err, client, done) => {
         this.logConnect(connectionStr, 'postgre');
         if(err){
           deferred.reject(err);


### PR DESCRIPTION
pg 模块从4.4升级到7.0之后使用不了了，使用方式有所改变，使用了连接池
但是有个内存溢出警告
```shell
(node:76692) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added. Use emitter.setMaxListeners() to increase limit
```
不知道会不会有影响？