### PR TITLE
处理export为箭头函数时的异常

### DIFF
--- a/src/core/think.js
+++ b/src/core/think.js
@@ -329,7 +329,7 @@ think.getPath = (module, type = think.dirname.controller, prefix = '') => {
  */
 let _loadRequire = (name, filepath) => {
   let obj = think.safeRequire(filepath);
-  if (think.isFunction(obj)) {
+  if (think.isFunction(obj) && obj.prototype) {
     obj.prototype.__filename = filepath;
   }
   if(obj){


### PR DESCRIPTION
箭头函数没有prototype