### PR TITLE
fix(typings): 修复 Koa 类型提示不正确，加入 Koa 的类型提示文件

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,13 @@
-
-import * as _Koa from 'koa';
-import * as Helper from 'think-helper';
-import * as ThinkCluster from 'think-cluster';
-import * as ThinkLogger from 'think-logger3';
+import * as _Koa from 'koa'
+import * as ThinkCluster from 'think-cluster'
+import * as Helper from 'think-helper'
+import * as ThinkLogger from 'think-logger3'
 
 declare namespace ThinkJs {
 
   export var think: Think;
 
-  export interface Koa extends _Koa {
+  export interface Koa extends _Koa.Context {
     think: Think;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,13 @@ declare namespace ThinkJs {
 
   export var think: Think;
 
-  export interface Koa extends _Koa.Context {
+  export interface Koa extends _Koa {
     think: Think;
   }
 
   class Controller {
-    constructor(ctx: Koa);
-    ctx: Koa;
+    constructor(ctx: Koa.Context);
+    ctx: Koa.Context;
     assign?(name: string, value: any): any;
     render?(file: string, config: object): Promise<string>;
     render?(config: object): Promise<string>;

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "think-validator": "^1.0.2"
   },
   "devDependencies": {
+    "@types/koa": "^2.0.39",
     "ava": "^0.18.0",
     "eslint": "^4.2.0",
     "eslint-config-think": "^1.0.2",


### PR DESCRIPTION
1. 修复 Koa 类型提示不正确

ctx 应该为 Koa 的 Context，而不是 Koa 本身。

2. 加入 Koa 的类型提示文件

Thinkjs 基于 Koa，核心的 ctx对象 的提示也依赖于 Koa 的类型提示文件。