### PR TITLE
fix: fix type of ctx.failed()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -303,7 +303,7 @@ declare module 'thinkjs' {
      * send fail data
      * @memberOf Controller
      */
-    fail(errno: any, errmsg?: string, data?: string): any;
+    fail(errno: any, errmsg?: string, data?: any): any;
     /**
      * set expires header
      * @memberOf Controller

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ declare module 'thinkjs' {
      * send fail data
      * @memberOf Context
      */
-    fail(errno: any, errmsg?: object | string, data?: string): any;
+    fail(errno: any, errmsg?: object | string, data?: any): any;
     /**
      * set expires header
      * @memberOf Context


### PR DESCRIPTION
`Controller.fail(errno: any, errmsg?: string, data?: string): any;` 中 data 参数使用 string，但是在 Logic 中使用的话，data 会传入 `Logic.validateErrors` ，而这里是个对象 （`Logic.validate(rules: Object, msgs?: Object): Object;`），我觉得 fail 方法 data 参数应该设置为 any 为好。