### PR TITLE
fix: add Logic.rule type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -469,6 +469,7 @@ declare module 'thinkjs' {
     validate(rules: Object, msgs?: Object): Object;
     validateErrors?: Object;
     allowMethods: string;
+    rules: Object;
   }
 
   export interface Think extends Helper.Think, ThinkConfig {


### PR DESCRIPTION
>自动调用校验方法。多数情况下都是校验失败后，输出一个 JSON 错误信息。如果不想每次都手动调用 this.validate 进行校验，可以通过将校验规则赋值给 this.rules 属性进行自动校验。https://www.thinkjs.org/zh-cn/doc/3.0/logic.html#toc-58b

这里并没有定义 Logic.rule