### PR TITLE
fix: types property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     }
   ],
   "main": "lib/application.js",
-  "type": "index.d.ts",
+  "types": "index.d.ts",
   "dependencies": {
     "bluebird": "3.3.5",
     "cookies": "^0.7.0",


### PR DESCRIPTION
>If your package has a main .js file, you will need to indicate the main declaration file in your package.json file as well. Set the `types `property to point to your bundled declaration file.  https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html