### PR TITLE
[feature] Auto detect test unit framework

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -181,6 +181,46 @@ module.exports = class Application {
     }, think.app);
   }
   /**
+   * check test env
+   */
+  _isRunInTest() {
+    const {
+      JEST_WORKER_ID,
+      NODE_ENV,
+      THINK_UNIT_TEST
+    } = process.env;
+
+    /**
+     * https://github.com/facebook/jest/pull/5860
+     * provide process.env.JEST_WORKER_ID="1" for cases when Jest * runs the tests on the main process.
+     */
+    const runInJest = JEST_WORKER_ID !== undefined;
+    /**
+     * https://github.com/avajs/ava/blob/master/docs/01-writing-tests.md
+     * AVA will set process.env.NODE_ENV to test, unless the
+     * NODE_ENV environment variable has been set.
+     */
+    const runInAva = NODE_ENV === 'test';
+
+    /**
+     * https://github.com/AndreasPizsa/detect-mocha/blob/master/index.js
+     */
+    const runInMocha = [
+      'afterEach',
+      'after',
+      'beforeEach',
+      'before',
+      'describe',
+      'it'
+    ].every(name => global[name] instanceof Function);
+
+    /**
+     * Other Test framework we can't detect should add environment * by user
+     */
+    const runInUserDefine = !!THINK_UNIT_TEST;
+    return runInJest || runInAva || runInMocha || runInUserDefine;
+  }
+  /**
    * run
    */
   run() {
@@ -193,7 +233,7 @@ module.exports = class Application {
     const instance = new ThinkLoader(this.options);
     const argv = this.parseArgv();
     try {
-      if (process.env.THINK_UNIT_TEST) {
+      if (this._isRunInTest()) {
         instance.loadAll('worker', true);
       } else if (argv.path) {
         instance.loadAll('worker', true);


### PR DESCRIPTION
Add [jest](https://jestjs.io/), [mocha](https://mochajs.org/) and [ava](https://github.com/avajs/ava) unit test framework auto detect logic to avoid set `THINK_UNIT_TEST` env variable by user manually.
 
relate issue https://github.com/thinkjs/thinkjs/issues/1404