### PR TITLE
replace url legacy API by WHATWG URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - '6'
-  - '7'
   - '8'
+  - '10'
+  - '12'
 sudo: false
 script:
     - "npm run test"

--- a/lib/extend/context.js
+++ b/lib/extend/context.js
@@ -1,6 +1,7 @@
 const helper = require('think-helper');
 const assert = require('assert');
 const Cookies = require('cookies');
+const {URL} = require('url');
 
 const PARAM = Symbol('context-param');
 const POST = Symbol('context-post');

--- a/lib/extend/context.js
+++ b/lib/extend/context.js
@@ -1,7 +1,6 @@
 const helper = require('think-helper');
 const assert = require('assert');
 const Cookies = require('cookies');
-const url = require('url');
 
 const PARAM = Symbol('context-param');
 const POST = Symbol('context-post');
@@ -52,7 +51,7 @@ module.exports = {
   referrer(onlyHost) {
     const referrer = this.header['referer'];
     if (!referrer || !onlyHost) return referrer;
-    return url.parse(referrer).hostname;
+    return new URL(referrer).hostname;
   },
   /**
    * is method


### PR DESCRIPTION
url legacy API is deprecated, replace it with WHATWG URL API because of security problem. see more here https://zhuanlan.zhihu.com/p/102338473