### PR TITLE
fix(postgresql): escape backslashes in string values

### DIFF
--- a/packages/think-model-postgresql/lib/parser.js
+++ b/packages/think-model-postgresql/lib/parser.js
@@ -124,6 +124,6 @@ module.exports = class PostgreSQLParser extends Parser {
    * @param {String} str
    */
   escapeString(str) {
-    return str.replace(/'/g, "\\'");
+    return str.replace(/[\\']/g, s => `\\${s}`);
   }
 };

--- a/packages/think-model-postgresql/test/parser.js
+++ b/packages/think-model-postgresql/test/parser.js
@@ -58,6 +58,8 @@ test('parseValue', t => {
   const data = [
     ['lizheming', "E'lizheming'"],
     ["I'm my wife's rock.", "E'I\\\'m my wife\\\'s rock.'"],
+    ['\\frac{1}{2}', "E'\\\\frac{1}{2}'"],
+    ['\\frac{1}{2} and I\\\'m ok', "E'\\\\frac{1}{2} and I\\\\\\'m ok'"],
     [3, 3],
     [{ a: 1 }, { a: 1 }],
     [null, 'null'],


### PR DESCRIPTION
### Motivation
- Prevent PostgreSQL `E''` string literals from interpreting sequences like `\f` (e.g. MathJax `\frac`) as control characters by ensuring backslashes are escaped before wrapping values.

### Description
- Replace `escapeString` implementation to escape both backslashes and single quotes (`return str.replace(/[\\']/g, s => `\\${s}`);`).
- Add parser regression tests for `\frac{1}{2}` and a mixed backslash + single-quote case to ensure backslashes are preserved in generated `E''` literals.

### Testing
- Ran the package tests with `npm test` in `packages/think-model-postgresql`, and the test suite passed (all parser tests passed; test run completed with coverage report).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38a3091d5083268c4a0bfda548bd67)