### PR TITLE
fix: quote PostgreSQL identifiers starting with digits

### DIFF
--- a/packages/think-model-postgresql/lib/parser.js
+++ b/packages/think-model-postgresql/lib/parser.js
@@ -10,9 +10,14 @@ module.exports = class PostgreSQLParser extends Parser {
    * @param {String} key
    */
   parseKey(key) {
-    if (!/^\w+$/.test(key)) return key;
+    if (!/^[A-Za-z0-9_$]+$/.test(key)) return key;
     const keyUpperCase = key.toUpperCase();
-    if (keywords.indexOf(keyUpperCase) > -1) return `"${key}"`;
+    if (
+      !/^[A-Za-z_]/.test(key) ||
+      keywords.indexOf(keyUpperCase) > -1
+    ) {
+      return `"${key}"`;
+    }
     return key;
   }
   /**

--- a/packages/think-model-postgresql/test/parser.js
+++ b/packages/think-model-postgresql/test/parser.js
@@ -2,12 +2,16 @@ const { test } = require('ava');
 const Parser = require('../lib/parser');
 
 test('parserKey', t => {
-  t.plan(3);
+  t.plan(7);
 
   const parser = new Parser();
   t.is(parser.parseKey('aa bb'), 'aa bb');
   t.is(parser.parseKey('lizheming'), 'lizheming');
+  t.is(parser.parseKey('userName'), 'userName');
   t.is(parser.parseKey('where'), '"where"');
+  t.is(parser.parseKey('2fa'), '"2fa"');
+  t.is(parser.parseKey('2fa_secret'), '"2fa_secret"');
+  t.is(parser.parseKey('count(*)'), 'count(*)');
 });
 
 test('parseGroup', t => {


### PR DESCRIPTION
## Summary

- Quote identifier-like PostgreSQL keys that cannot be used unquoted because they start with a digit.
- Preserve the existing behavior for ordinary identifiers and raw SQL expressions.
- Add regression coverage for `2fa`, keywords, camel-cased identifiers, and expressions.

## Why

`parseKey()` currently treats `2fa` as a word key and emits it without quotes. PostgreSQL identifiers cannot start with a digit unless they are delimited, so this produces invalid SQL for schemas such as Waline's `"2fa"` column.

Version 1.1.7 avoided this by quoting every key, but that behavior was reverted in 1.1.8 because it changed existing identifier semantics too broadly. This change keeps the 1.1.8 compatibility behavior while quoting only identifier-like keys that require delimiters, in addition to the existing keyword handling.

## Validation

- `pnpm --filter think-model-postgresql eslint`
- `pnpm --filter think-model-postgresql test-cov` — 36 passed, 1 existing todo
