### PR TITLE
test: pad current day in datetime expectation

### DIFF
--- a/packages/think-helper/test/index.js
+++ b/packages/think-helper/test/index.js
@@ -339,7 +339,7 @@ test('datetime 1', t => {
     [
       now.getFullYear(),
       ('0' + (now.getMonth() + 1)).slice(-2),
-      now.getDate()
+      ('0' + now.getDate()).slice(-2)
     ].join('/')
   );
 });


### PR DESCRIPTION
## Summary

- pad the current day to two digits in the `think-helper` datetime test expectation
- keep the expectation aligned with the `DD` formatter behavior

## Root cause

The test padded the current month but used `Date#getDate()` directly. On days 1–9, it expected values such as `2026/08/4`, while `datetime('YYYY/MM/DD')` correctly returned `2026/08/04`. This caused all Node.js matrix jobs to fail during the first nine days of each month.

## Validation

- `npx --yes pnpm@11.6.0 --filter think-helper test` — 77 tests passed
- `git diff --check`

The full GitHub Actions Node.js 22/24/26 matrix will provide final verification with the required Redis service.