### PR TITLE
fix(postgresql): escape backslashes in string values

### DIFF
--- a/packages/think-model-postgresql/lib/parser.js
+++ b/packages/think-model-postgresql/lib/parser.js
@@ -129,6 +129,6 @@ module.exports = class PostgreSQLParser extends Parser {
    * @param {String} str
    */
   escapeString(str) {
-    return str.replace(/'/g, "\\'");
+    return str.replace(/['\\]/g, char => `\\${char}`);
   }
 };

--- a/packages/think-model-postgresql/test/parser.js
+++ b/packages/think-model-postgresql/test/parser.js
@@ -62,6 +62,12 @@ test('parseValue', t => {
   const data = [
     ['lizheming', "E'lizheming'"],
     ["I'm my wife's rock.", "E'I\\\'m my wife\\\'s rock.'"],
+    ['test $\\frac{1}{2}$', "E'test $\\\\frac{1}{2}$'"],
+    [
+      '\\b\\f\\n\\r\\t\\123\\x41\\u0041\\U00000041',
+      "E'\\\\b\\\\f\\\\n\\\\r\\\\t\\\\123\\\\x41\\\\u0041\\\\U00000041'"
+    ],
+    ["\\'", "E'\\\\\\\''"],
     [3, 3],
     [{ a: 1 }, { a: 1 }],
     [null, 'null'],


### PR DESCRIPTION
## Summary

- escape backslashes as well as single quotes when building PostgreSQL `E'...'` string literals
- add regression coverage for LaTeX input, PostgreSQL C-style escape sequences, and a backslash followed by a quote

## Root cause

`think-model-postgresql` emits string values as PostgreSQL escape string constants, but `escapeString` previously escaped only single quotes. PostgreSQL therefore interpreted input such as `\frac` as a C-style escape and stored `\f` as a form-feed character.

This fixes the root cause reported in walinejs/waline#3645 while preserving the existing SQL generation approach.

## Validation

- `pnpm --filter think-model-postgresql test`
- 36 tests passed, 1 existing todo
