### PR TITLE
Update think-helper dependencies

### DIFF
--- a/packages/think-helper/.eslintrc
+++ b/packages/think-helper/.eslintrc
@@ -1,3 +1,0 @@
-{
-    "extends": "think"
-}

--- a/packages/think-helper/eslint.config.js
+++ b/packages/think-helper/eslint.config.js
@@ -1,0 +1,28 @@
+const js = require('@eslint/js');
+const globals = require('globals');
+
+module.exports = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: {
+        ...globals.node,
+        think: 'readonly'
+      }
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      'no-console': ['error', {allow: ['warn', 'error']}],
+      'no-constant-binary-expression': 'off',
+      'no-unused-vars': ['error', {args: 'none', caughtErrors: 'none'}]
+    }
+  },
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      sourceType: 'module'
+    }
+  }
+];

--- a/packages/think-helper/package.json
+++ b/packages/think-helper/package.json
@@ -13,9 +13,7 @@
     "lint-fix": "eslint --fix index.js"
   },
   "ava": {
-    "require": [
-      "babel-core/register"
-    ]
+    "failWithoutAssertions": false
   },
   "contributors": [
     {
@@ -26,18 +24,19 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "core-util-is": "^1.0.2",
+    "core-util-is": "^1.0.3",
     "lodash.merge": "^4.6.2",
-    "ms": "^1.0.0",
-    "uuid": "^7.0.3"
+    "ms": "^2.1.3",
+    "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "ava": "^0.18.0",
-    "codecov": "^3.7.1",
-    "coveralls": "^2.11.16",
-    "eslint": "^4.2.0",
-    "eslint-config-think": "^1.0.1",
-    "nyc": "^7.1.0"
+    "@eslint/js": "^10.0.1",
+    "ava": "^8.0.1",
+    "codecov": "^3.8.3",
+    "coveralls": "^3.1.1",
+    "eslint": "^10.8.0",
+    "globals": "^17.9.0",
+    "nyc": "^18.0.0"
   },
   "keywords": [],
   "repository": {
@@ -46,7 +45,7 @@
     "directory": "packages/think-helper"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=20.19.0"
   },
   "readmeFilename": "README.md",
   "bugs": {

--- a/packages/think-helper/test/index.js
+++ b/packages/think-helper/test/index.js
@@ -30,6 +30,10 @@ import {
 } from '../index.js';
 import fs from 'fs';
 import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 test('isInt', t => {
   t.is(isInt(42), true);
@@ -504,7 +508,7 @@ test('parseAdapterConfig 3', t => {
   t.deepEqual(parseAdapterConfig(value, extConfig2).type, 'ejs');
 });
 
-test('parseAdapterConfig 3', t => {
+test('parseAdapterConfig empty config', t => {
   const value = parseAdapterConfig({});
   t.deepEqual(parseAdapterConfig(value).type, '_');
 });
@@ -540,7 +544,7 @@ test('parseAdapterConfig 6', t => {
   t.deepEqual(value.timeout, 20);
 });
 
-test('omit 1', t => {
+test('omit existing key', t => {
   const value = omit({
     a: 1,
     b: 2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 4.2.0(supports-color@6.1.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.2.0(supports-color@6.1.0))
+        version: 1.1.0(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0)
       nyc:
         specifier: ~10.1.2
         version: 10.1.2
@@ -85,7 +85,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -245,7 +245,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^13.0.0
         version: 13.3.0
@@ -270,7 +270,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -298,7 +298,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^7.1.0
         version: 7.1.0
@@ -314,7 +314,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -326,7 +326,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.0
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -363,7 +363,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -375,7 +375,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -439,7 +439,7 @@ importers:
         version: 0.14.0(supports-color@6.1.0)
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -448,7 +448,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^7.0.0
         version: 7.1.0
@@ -575,7 +575,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -587,7 +587,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^7.0.0
         version: 7.1.0
@@ -606,7 +606,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^11.3.0
         version: 11.9.0
@@ -614,36 +614,39 @@ importers:
   packages/think-helper:
     dependencies:
       core-util-is:
-        specifier: ^1.0.2
+        specifier: ^1.0.3
         version: 1.0.3
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
       ms:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^2.1.3
+        version: 2.1.3
       uuid:
-        specifier: ^7.0.3
-        version: 7.0.3
+        specifier: ^14.0.1
+        version: 14.0.1
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.0)
       ava:
-        specifier: ^0.18.0
-        version: 0.18.2
+        specifier: ^8.0.1
+        version: 8.0.1(encoding@0.1.13)
       codecov:
-        specifier: ^3.7.1
-        version: 3.8.3(encoding@0.1.13)(supports-color@6.1.0)
+        specifier: ^3.8.3
+        version: 3.8.3(encoding@0.1.13)
       coveralls:
-        specifier: ^2.11.16
-        version: 2.13.3
+        specifier: ^3.1.1
+        version: 3.1.1
       eslint:
-        specifier: ^4.2.0
-        version: 4.19.1(supports-color@5.5.0)
-      eslint-config-think:
-        specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        specifier: ^10.8.0
+        version: 10.8.0
+      globals:
+        specifier: ^17.9.0
+        version: 17.9.0
       nyc:
-        specifier: ^7.1.0
-        version: 7.1.0
+        specifier: ^18.0.0
+        version: 18.0.0
 
   packages/think-i18n:
     dependencies:
@@ -668,7 +671,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -699,7 +702,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -708,7 +711,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -789,7 +792,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.3
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -864,7 +867,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -876,7 +879,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.0
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -932,7 +935,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1003,7 +1006,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1055,7 +1058,7 @@ importers:
         version: 6.26.0
       babel-core:
         specifier: ^6.26.0
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -1067,7 +1070,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1098,7 +1101,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1129,7 +1132,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1160,7 +1163,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1194,7 +1197,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^3.0.2
         version: 3.0.3
@@ -1234,7 +1237,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1268,7 +1271,7 @@ importers:
         version: 6.26.0
       babel-core:
         specifier: ^6.24.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -1280,7 +1283,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       muk:
         specifier: ^0.5.3
         version: 0.5.3
@@ -1348,7 +1351,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1360,7 +1363,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -1397,7 +1400,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1409,7 +1412,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -1434,7 +1437,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       istanbul:
         specifier: 0.4.0
         version: 0.4.0
@@ -1495,7 +1498,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1538,7 +1541,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^11.3.0
         version: 11.9.0
@@ -1557,7 +1560,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^7.0.0
         version: 7.1.0
@@ -1588,7 +1591,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mockery:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1696,7 +1699,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mockery:
         specifier: ~2.0.0
         version: 2.0.0
@@ -1718,7 +1721,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       nyc:
         specifier: ^11.2.1
         version: 11.9.0
@@ -1746,7 +1749,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1774,7 +1777,7 @@ importers:
         version: 8.0.1(encoding@0.1.13)
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       coveralls:
         specifier: ^2.12.0
         version: 2.13.3
@@ -1783,7 +1786,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -1811,7 +1814,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -1823,7 +1826,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -1863,7 +1866,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -1875,7 +1878,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -1906,7 +1909,7 @@ importers:
         version: 0.22.0
       babel-core:
         specifier: ^6.26.0
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -1918,7 +1921,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1943,7 +1946,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       coveralls:
         specifier: ^2.12.0
         version: 2.13.3
@@ -1983,7 +1986,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -1995,7 +1998,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -2110,7 +2113,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.26.0
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -2128,7 +2131,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       extract-text-webpack-plugin:
         specifier: ^2.1.2
         version: 2.1.2(webpack@2.7.0)
@@ -2208,7 +2211,7 @@ importers:
         version: 6.26.0
       babel-core:
         specifier: 6.x.x
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: 4.1.3
         version: 4.1.3
@@ -2279,7 +2282,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -2291,7 +2294,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -2316,7 +2319,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.2.3
         version: 7.2.3
@@ -2325,7 +2328,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mock-require:
         specifier: ^2.0.1
         version: 2.0.2
@@ -2434,7 +2437,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -2446,7 +2449,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.1
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -2480,7 +2483,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -2520,7 +2523,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -2563,7 +2566,7 @@ importers:
         version: 0.18.2
       babel-core:
         specifier: ^6.22.1
-        version: 6.26.3(supports-color@6.1.0)
+        version: 6.26.3
       babel-eslint:
         specifier: ^7.1.1
         version: 7.2.3
@@ -2660,7 +2663,7 @@ importers:
         version: 4.19.1(supports-color@5.5.0)
       eslint-config-think:
         specifier: ^1.0.2
-        version: 1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 1.1.0(eslint@4.19.1)
       mkdirp:
         specifier: ^0.5.1
         version: 0.5.6
@@ -3295,6 +3298,18 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/eslintrc@0.4.3':
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3303,9 +3318,38 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -3328,6 +3372,10 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -3514,6 +3562,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -3522,6 +3573,9 @@ packages:
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -6247,6 +6301,10 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-utils@1.4.3:
     resolution: {integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==}
     engines: {node: '>=6'}
@@ -6267,11 +6325,25 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@1.8.0:
     resolution: {integrity: sha512-WZGdy/1xpWBkJF8r06SxLT9tjBc6/nCXn1Mfj7M3uNglMPtnTmS6py7xuFNRUykNZ5WWNWTYjI3JcAXsdXhA7w==}
     engines: {node: '>=0.10'}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   eslint@2.8.0:
     resolution: {integrity: sha512-fl+zgds1WPuQYJQfSRHacMq0qZ8UKLQYRe/Iz/NL9ISOCDIA+QhjeP1INcvbZ5kpK5AsF9Bks4diDD38YeMlLA==}
@@ -6355,6 +6427,10 @@ packages:
 
   espower-location-detector@1.0.0:
     resolution: {integrity: sha512-Y/3H6ytYwqC3YcOc0gOU22Lp3eI5GAFGOymTdzFyfaiglKgtsw2dePOgXY3yrV+QcLPMPiVYwBU9RKaDoh2bbQ==}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   espree@2.2.5:
     resolution: {integrity: sha512-HWJpgkL44cbjWiOTC9Pm34RZE57H1g9V4Ln9U14TUtiywFTLMMpMCtmQK5rkjbGBXigQT8bS3r45+Dt5+m0SZg==}
@@ -6624,6 +6700,10 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-loader@0.10.1:
     resolution: {integrity: sha512-MDhQNyTgdJpBnBveHgNgDwROzt+1YajNh2RL3fwhicFDPRReTcxsNnaHVUj1wVKU61VaqouQNsq2Ssiqxw4V+g==}
 
@@ -6740,6 +6820,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@2.0.2:
     resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
@@ -7030,6 +7114,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
+    engines: {node: '>=18'}
 
   globals@6.4.1:
     resolution: {integrity: sha512-Lh7H0bYRNBMc2CapY+TYsCzcSM4HWHGFoQORuEcePk3y3IhpaZmFSJDirhNYSwq8QeHvaCqV/tHI2bdUhYryuw==}
@@ -12401,6 +12489,10 @@ packages:
     resolution: {integrity: sha512-PYxZDA+6QtvRvm//++aGdmKG/cI07jNwbROz0Ql+VzFV1+Z0Dy55NI4zZ7RHc9KKpBePNFwoErqIuqQv/cjiTA==}
     engines: {node: '>= 0.12.0'}
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   uuid@2.0.3:
     resolution: {integrity: sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -13733,12 +13825,33 @@ snapshots:
 
   '@cto.af/wtf8@0.0.5': {}
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0)':
+    dependencies:
+      eslint: 10.8.0
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@6.1.0))':
     dependencies:
       eslint: 8.57.1(supports-color@6.1.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@6.1.0)
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@0.4.3(supports-color@6.1.0)':
     dependencies:
@@ -13768,7 +13881,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/js@10.0.1(eslint@10.8.0)':
+    optionalDependencies:
+      eslint: 10.8.0
+
   '@eslint/js@8.57.1': {}
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/config-array@0.13.0(supports-color@6.1.0)':
     dependencies:
@@ -13791,6 +13927,8 @@ snapshots:
   '@humanwhocodes/object-schema@1.2.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -14082,6 +14220,8 @@ snapshots:
     dependencies:
       '@types/node': 8.10.66
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@1.0.6': {}
@@ -14090,6 +14230,8 @@ snapshots:
     dependencies:
       '@types/minimatch': 6.0.0
       '@types/node': 8.10.66
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
@@ -14249,7 +14391,7 @@ snapshots:
 
   agent-base@5.1.1: {}
 
-  agent-base@6.0.2(supports-color@6.1.0):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@6.1.0)
     transitivePeerDependencies:
@@ -14610,7 +14752,7 @@ snapshots:
       array-uniq: 1.0.3
       arrify: 1.0.1
       ava-init: 0.1.6
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       babel-plugin-detective: 1.0.2
       babel-plugin-espower: 2.4.0
       babel-plugin-transform-runtime: 6.23.0
@@ -14685,7 +14827,7 @@ snapshots:
       auto-bind: 1.2.1
       ava-init: 0.2.1
       babel-code-frame: 6.26.0
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       bluebird: 3.7.2
       caching-transform: 1.0.1
       chalk: 1.1.3
@@ -14763,7 +14905,7 @@ snapshots:
       auto-bind: 1.2.1
       ava-init: 0.2.1
       babel-code-frame: 6.26.0
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       bluebird: 3.7.2
       caching-transform: 1.0.1
       chalk: 1.1.3
@@ -15490,7 +15632,7 @@ snapshots:
 
   babel-cli@6.23.0:
     dependencies:
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       babel-polyfill: 6.26.0
       babel-register: 6.26.0
       babel-runtime: 6.26.0
@@ -15511,7 +15653,7 @@ snapshots:
 
   babel-cli@6.26.0:
     dependencies:
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       babel-polyfill: 6.26.0
       babel-register: 6.26.0
       babel-runtime: 6.26.0
@@ -15611,6 +15753,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-core@6.26.3:
+    dependencies:
+      babel-code-frame: 6.26.0
+      babel-generator: 6.26.1
+      babel-helpers: 6.24.1
+      babel-messages: 6.23.0
+      babel-register: 6.26.0
+      babel-runtime: 6.26.0
+      babel-template: 6.26.0
+      babel-traverse: 6.26.0
+      babel-types: 6.26.0
+      babylon: 6.18.0
+      convert-source-map: 1.9.0
+      debug: 2.6.9(supports-color@6.1.0)
+      json5: 0.5.1
+      lodash: 4.18.1
+      minimatch: 3.1.5
+      path-is-absolute: 1.0.1
+      private: 0.1.8
+      slash: 1.0.0
+      source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
+
   babel-core@6.26.3(supports-color@3.2.3):
     dependencies:
       babel-code-frame: 6.26.0
@@ -15665,7 +15831,7 @@ snapshots:
       babel-generator: 6.26.1
       babel-helpers: 6.24.1(supports-color@5.5.0)
       babel-messages: 6.23.0
-      babel-register: 6.26.0(supports-color@5.5.0)
+      babel-register: 6.26.0
       babel-runtime: 6.26.0
       babel-template: 6.26.0(supports-color@5.5.0)
       babel-traverse: 6.26.0(supports-color@5.5.0)
@@ -15673,30 +15839,6 @@ snapshots:
       babylon: 6.18.0
       convert-source-map: 1.9.0
       debug: 2.6.9(supports-color@5.5.0)
-      json5: 0.5.1
-      lodash: 4.18.1
-      minimatch: 3.1.5
-      path-is-absolute: 1.0.1
-      private: 0.1.8
-      slash: 1.0.0
-      source-map: 0.5.7
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-core@6.26.3(supports-color@6.1.0):
-    dependencies:
-      babel-code-frame: 6.26.0
-      babel-generator: 6.26.1
-      babel-helpers: 6.24.1
-      babel-messages: 6.23.0
-      babel-register: 6.26.0
-      babel-runtime: 6.26.0
-      babel-template: 6.26.0
-      babel-traverse: 6.26.0
-      babel-types: 6.26.0
-      babylon: 6.18.0
-      convert-source-map: 1.9.0
-      debug: 2.6.9(supports-color@6.1.0)
       json5: 0.5.1
       lodash: 4.18.1
       minimatch: 3.1.5
@@ -16098,7 +16240,7 @@ snapshots:
 
   babel-loader@6.4.1(babel-core@6.26.3)(webpack@2.7.0):
     dependencies:
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       find-cache-dir: 0.1.1
       loader-utils: 0.2.17
       mkdirp: 0.5.6
@@ -16674,19 +16816,7 @@ snapshots:
 
   babel-register@6.26.0:
     dependencies:
-      babel-core: 6.26.3(supports-color@6.1.0)
-      babel-runtime: 6.26.0
-      core-js: 2.6.12
-      home-or-tmp: 2.0.0
-      lodash: 4.18.1
-      mkdirp: 0.5.6
-      source-map-support: 0.4.18
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-register@6.26.0(supports-color@5.5.0):
-    dependencies:
-      babel-core: 6.26.3(supports-color@5.5.0)
+      babel-core: 6.26.3
       babel-runtime: 6.26.0
       core-js: 2.6.12
       home-or-tmp: 2.0.0
@@ -17617,12 +17747,12 @@ snapshots:
       request: 2.88.2
       urlgrey: 2.1.0
 
-  codecov@3.8.3(encoding@0.1.13)(supports-color@6.1.0):
+  codecov@3.8.3(encoding@0.1.13):
     dependencies:
       argv: 0.0.2
       ignore-walk: 3.0.4
       js-yaml: 3.14.1
-      teeny-request: 7.1.1(encoding@0.1.13)(supports-color@6.1.0)
+      teeny-request: 7.1.1(encoding@0.1.13)
       urlgrey: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -17800,7 +17930,7 @@ snapshots:
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
-      babel-core: 6.26.3(supports-color@6.1.0)
+      babel-core: 6.26.3
       ejs: 2.7.4
       handlebars: 4.7.9
       lodash: 4.18.1
@@ -18797,7 +18927,7 @@ snapshots:
   eslint-config-think@1.0.3(eslint@4.2.0):
     dependencies:
       babel-eslint: 10.1.0(eslint@4.2.0)
-      eslint-plugin-import: 2.32.0(eslint@4.2.0)
+      eslint-plugin-import: 2.32.0(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0)
       eslint-plugin-node: 5.2.1(eslint@4.2.0)
       eslint-plugin-promise: 3.8.0
       eslint-plugin-standard: 3.1.0(eslint@4.2.0)
@@ -18877,9 +19007,9 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-think@1.1.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0):
+  eslint-config-think@1.1.0(eslint@4.19.1):
     dependencies:
-      eslint-plugin-import: 2.32.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+      eslint-plugin-import: 2.32.0(eslint@4.19.1)
       eslint-plugin-node: 5.2.1(eslint@4.19.1)
       eslint-plugin-promise: 3.8.0
       eslint-plugin-standard: 3.1.0(eslint@4.19.1)
@@ -18890,9 +19020,9 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-think@1.1.0(eslint@4.2.0(supports-color@6.1.0)):
+  eslint-config-think@1.1.0(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0):
     dependencies:
-      eslint-plugin-import: 2.32.0(eslint@4.2.0)
+      eslint-plugin-import: 2.32.0(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0)
       eslint-plugin-node: 5.2.1(eslint@4.2.0)
       eslint-plugin-promise: 3.8.0
       eslint-plugin-standard: 3.1.0(eslint@4.2.0)
@@ -18963,11 +19093,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10(supports-color@5.5.0))(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10(supports-color@5.5.0))(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
-      eslint: 4.19.1(supports-color@5.5.0)
+      eslint: 4.2.0(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.10(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -18999,11 +19129,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@4.2.0):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@4.19.1):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
-      eslint: 4.2.0(supports-color@6.1.0)
+      eslint: 4.19.1(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -19158,7 +19288,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0):
+  eslint-plugin-import@2.32.0(eslint@4.19.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19169,7 +19299,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 4.19.1(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10(supports-color@5.5.0)
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10(supports-color@5.5.0))(eslint@4.19.1(supports-color@5.5.0))(supports-color@5.5.0)
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@4.19.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -19185,7 +19315,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@4.2.0):
+  eslint-plugin-import@2.32.0(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19196,7 +19326,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 4.2.0(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.10(supports-color@5.5.0)
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@4.2.0)
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10(supports-color@5.5.0))(eslint@4.2.0(supports-color@6.1.0))(supports-color@5.5.0)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -19581,6 +19711,13 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-utils@1.4.3:
     dependencies:
       eslint-visitor-keys: 1.3.0
@@ -19594,6 +19731,8 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@1.8.0(supports-color@6.1.0):
     dependencies:
@@ -19632,6 +19771,41 @@ snapshots:
       to-single-quotes: 1.0.4
       user-home: 1.1.1
       xml-escape: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@10.8.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@6.1.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
     transitivePeerDependencies:
       - supports-color
 
@@ -20190,6 +20364,12 @@ snapshots:
       source-map: 0.5.7
       xtend: 4.0.2
 
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   espree@2.2.5: {}
 
   espree@3.1.3:
@@ -20552,6 +20732,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-loader@0.10.1:
     dependencies:
       loader-utils: 1.4.2
@@ -20689,6 +20873,11 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
 
   flatted@2.0.2: {}
 
@@ -20995,6 +21184,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@17.9.0: {}
 
   globals@6.4.1: {}
 
@@ -21409,10 +21600,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@4.0.1(supports-color@6.1.0):
+  http-proxy-agent@4.0.1:
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2(supports-color@6.1.0)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -21438,9 +21629,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1(supports-color@6.1.0):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@6.1.0)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -26291,10 +26482,10 @@ snapshots:
 
   tarn@2.0.0: {}
 
-  teeny-request@7.1.1(encoding@0.1.13)(supports-color@6.1.0):
+  teeny-request@7.1.1(encoding@0.1.13):
     dependencies:
-      http-proxy-agent: 4.0.1(supports-color@6.1.0)
-      https-proxy-agent: 5.0.1(supports-color@6.1.0)
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 8.3.2
@@ -27173,6 +27364,8 @@ snapshots:
       mkdirp: 0.5.6
       mz: 2.7.0
       unescape: 1.0.1
+
+  uuid@14.0.1: {}
 
   uuid@2.0.3: {}
 


### PR DESCRIPTION
## What changed

Updated `think-helper` dependencies to their latest npm releases:

### Runtime dependencies

- `core-util-is`: `^1.0.2` → `^1.0.3`
- `ms`: `^1.0.0` → `^2.1.3`
- `uuid`: `^7.0.3` → `^14.0.1`
- `lodash.merge` remains at the latest `^4.6.2`

### Development dependencies

- `ava`: `^0.18.0` → `^8.0.1`
- `codecov`: `^3.7.1` → `^3.8.3`
- `coveralls`: `^2.11.16` → `^3.1.1`
- `eslint`: `^4.2.0` → `^10.8.0`
- `nyc`: `^7.1.0` → `^18.0.0`
- replaced the legacy `eslint-config-think` setup with current flat-config dependencies: `@eslint/js@10.0.1` and `globals@17.9.0`

`codecov@3.8.3` is deprecated, but is still the latest published version of that package.

## Compatibility updates

- migrated ESLint from `.eslintrc` to `eslint.config.js`, as ESLint 10 only supports flat config
- removed the legacy Babel registration from AVA and updated the tests for native ESM execution
- made duplicate AVA test titles unique
- raised the package Node.js requirement from 6 to 20.19; `uuid` has been ESM-only since v12, and Node 20.19 provides synchronous ESM loading for the existing CommonJS `require('uuid')` integration
- regenerated the workspace lockfile with the repository-declared pnpm 11.6.0

## Validation

- frozen workspace install with pnpm 11.6.0
- `pnpm --filter think-helper lint`
- `pnpm --filter think-helper exec nyc ava test/` — 77 tests passed
- `packages/thinkjs` test suite — 92 tests passed
- `think-validator` test suite — 177 tests passed, 100% coverage
- runtime smoke test for UUID v1/v4 generation and `ms()` conversion