### PR TITLE
fix(ci): use Node 22 for package publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

- update the package publishing workflow from Node.js 20.x to 22.x
- keep pnpm pinned to 11.6.0 and leave the rest of the publishing flow unchanged

## Why

The publish workflow introduced in #1782 fails during `actions/setup-node` cache setup because pnpm 11.6.0 requires Node.js 22.13 or newer. Under Node.js 20.20.2, `pnpm store path` exits with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`.

Failed run: https://github.com/thinkjs/thinkjs/actions/runs/31146438702

Using `22.x` satisfies pnpm's minimum runtime requirement while continuing to receive the latest compatible Node.js 22 maintenance release.

## Validation

- inspected the failed GitHub Actions log and confirmed the Node/pnpm incompatibility
- parsed `.github/workflows/publish-packages.yml` successfully
- `git diff --check`
- confirmed pnpm 11.6.0 runs on a supported newer Node.js runtime