### PR TITLE
set test environment for thinkjs tests

### DIFF
--- a/packages/thinkjs/package.json
+++ b/packages/thinkjs/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "pnpm run lint && pnpm run test-cov",
-    "test-cov": "node --test --test-concurrency=1 --experimental-test-coverage test/case/application.js test/case/extend/context.js test/case/extend/controller.js test/case/extend/logic.js test/case/loader.js test/case/think.js",
+    "test-cov": "NODE_ENV=test node --test --test-concurrency=1 --experimental-test-coverage test/case/application.js test/case/extend/context.js test/case/extend/controller.js test/case/extend/logic.js test/case/loader.js test/case/think.js",
     "lint": "eslint ./lib/",
     "prepublish": "pnpm test"
   },


### PR DESCRIPTION
## Summary

- set `NODE_ENV=test` when running the `thinkjs` package test suite
- preserve the test execution path previously provided automatically by AVA

## Root cause

After #1785 migrated the suite from AVA to `node:test`, the runner no longer initialized `NODE_ENV` to `test`. As a result, `Application._isRunInTest()` could return false and exercise the development/master startup path during tests.

This addresses the issue identified in [the Codex review comment](https://github.com/thinkjs/thinkjs/pull/1785#discussion_r3733976353).

## Validation

- `pnpm test` in `packages/thinkjs` — 92 tests passed
- confirmed the command starts with `NODE_ENV=test`
- confirmed the output does not contain `Server running` or `Environment: development`
- `git diff --check`