### PR TITLE
Add project and module coverage reporting

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,6 +4,7 @@
     "packages/**/*.js"
   ],
   "exclude": [
+    "packages/think-model/src/**",
     "packages/**/test/**",
     "packages/**/*.test.js",
     "packages/**/eslint.config.js",

--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,18 @@
+{
+  "all": true,
+  "include": [
+    "packages/**/*.js"
+  ],
+  "exclude": [
+    "packages/**/test/**",
+    "packages/**/*.test.js",
+    "packages/**/eslint.config.js",
+    "packages/**/webpack.config.js"
+  ],
+  "reporter": [
+    "text-summary",
+    "lcov"
+  ],
+  "reports-dir": "coverage",
+  "exclude-after-remap": true
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -51,4 +52,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
+        if: matrix.node-version != '24.x'
         run: pnpm lint && pnpm test
+
+      - name: Run tests with coverage
+        if: matrix.node-version == '24.x'
+        run: pnpm lint && pnpm coverage
+
+      - name: Upload coverage to Codecov
+        if: matrix.node-version == '24.x'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          use_oidc: true
+          fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
+          disable_search: true
           use_oidc: true
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
     <a href="https://travis-ci.org/thinkjs/thinkjs">
       <img src="https://img.shields.io/travis/thinkjs/thinkjs.svg?style=flat-square" alt="travis-ci" />
     </a>
-    <a href="https://coveralls.io/github/thinkjs/thinkjs">
-      <img src="https://img.shields.io/coveralls/thinkjs/thinkjs.svg?style=flat-square" alt="Coverage Status" />
+    <a href="https://codecov.io/gh/thinkjs/thinkjs">
+      <img src="https://codecov.io/gh/thinkjs/thinkjs/branch/master/graph/badge.svg" alt="Coverage Status" />
     </a>
     <a href="https://david-dm.org/thinkjs/thinkjs">
       <img src="https://img.shields.io/david/thinkjs/thinkjs.svg?style=flat-square" alt="Dependency Status" />

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -12,8 +12,8 @@
     <a href="https://travis-ci.org/thinkjs/thinkjs">
       <img src="https://img.shields.io/travis/thinkjs/thinkjs.svg?style=flat-square" alt="travis-ci" />
     </a>
-    <a href="https://coveralls.io/github/thinkjs/thinkjs">
-      <img src="https://img.shields.io/coveralls/thinkjs/thinkjs.svg?style=flat-square" alt="Coverage Status" />
+    <a href="https://codecov.io/gh/thinkjs/thinkjs">
+      <img src="https://codecov.io/gh/thinkjs/thinkjs/branch/master/graph/badge.svg" alt="Coverage Status" />
     </a>
     <a href="https://david-dm.org/thinkjs/thinkjs">
       <img src="https://img.shields.io/david/thinkjs/thinkjs.svg?style=flat-square" alt="Dependency Status" />

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,324 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "header, diff, components, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+        informational: true
+  individual_components:
+    - component_id: think-apollo-graphql
+      name: think-apollo-graphql
+      paths:
+        - "packages/think-apollo-graphql/**"
+    - component_id: think-awesome
+      name: think-awesome
+      paths:
+        - "packages/think-awesome/**"
+    - component_id: think-babel
+      name: think-babel
+      paths:
+        - "packages/think-babel/**"
+    - component_id: think-cache
+      name: think-cache
+      paths:
+        - "packages/think-cache/**"
+    - component_id: think-cache-file
+      name: think-cache-file
+      paths:
+        - "packages/think-cache-file/**"
+    - component_id: think-cache-memcache
+      name: think-cache-memcache
+      paths:
+        - "packages/think-cache-memcache/**"
+    - component_id: think-cache-redis
+      name: think-cache-redis
+      paths:
+        - "packages/think-cache-redis/**"
+    - component_id: think-cli
+      name: think-cli
+      paths:
+        - "packages/think-cli/**"
+    - component_id: think-cluster
+      name: think-cluster
+      paths:
+        - "packages/think-cluster/**"
+    - component_id: think-config
+      name: think-config
+      paths:
+        - "packages/think-config/**"
+    - component_id: think-controller
+      name: think-controller
+      paths:
+        - "packages/think-controller/**"
+    - component_id: think-crontab
+      name: think-crontab
+      paths:
+        - "packages/think-crontab/**"
+    - component_id: think-csrf
+      name: think-csrf
+      paths:
+        - "packages/think-csrf/**"
+    - component_id: think-debounce
+      name: think-debounce
+      paths:
+        - "packages/think-debounce/**"
+    - component_id: think-demo
+      name: think-demo
+      paths:
+        - "packages/think-demo/**"
+    - component_id: think-email
+      name: think-email
+      paths:
+        - "packages/think-email/**"
+    - component_id: think-fetch
+      name: think-fetch
+      paths:
+        - "packages/think-fetch/**"
+    - component_id: think-gc
+      name: think-gc
+      paths:
+        - "packages/think-gc/**"
+    - component_id: think-helmet
+      name: think-helmet
+      paths:
+        - "packages/think-helmet/**"
+    - component_id: think-helper
+      name: think-helper
+      paths:
+        - "packages/think-helper/**"
+    - component_id: think-i18n
+      name: think-i18n
+      paths:
+        - "packages/think-i18n/**"
+    - component_id: think-inspect
+      name: think-inspect
+      paths:
+        - "packages/think-inspect/**"
+    - component_id: think-instance
+      name: think-instance
+      paths:
+        - "packages/think-instance/**"
+    - component_id: think-knex
+      name: think-knex
+      paths:
+        - "packages/think-knex/**"
+    - component_id: think-loader
+      name: think-loader
+      paths:
+        - "packages/think-loader/**"
+    - component_id: think-logger
+      name: think-logger
+      paths:
+        - "packages/think-logger/**"
+    - component_id: think-logger3
+      name: think-logger3
+      paths:
+        - "packages/think-logger3/**"
+    - component_id: think-logic
+      name: think-logic
+      paths:
+        - "packages/think-logic/**"
+    - component_id: think-memcache
+      name: think-memcache
+      paths:
+        - "packages/think-memcache/**"
+    - component_id: think-meta
+      name: think-meta
+      paths:
+        - "packages/think-meta/**"
+    - component_id: think-mock
+      name: think-mock
+      paths:
+        - "packages/think-mock/**"
+    - component_id: think-mock-http
+      name: think-mock-http
+      paths:
+        - "packages/think-mock-http/**"
+    - component_id: think-model
+      name: think-model
+      paths:
+        - "packages/think-model/**"
+    - component_id: think-model-abstract
+      name: think-model-abstract
+      paths:
+        - "packages/think-model-abstract/**"
+    - component_id: think-model-mysql
+      name: think-model-mysql
+      paths:
+        - "packages/think-model-mysql/**"
+    - component_id: think-model-mysql2
+      name: think-model-mysql2
+      paths:
+        - "packages/think-model-mysql2/**"
+    - component_id: think-model-postgresql
+      name: think-model-postgresql
+      paths:
+        - "packages/think-model-postgresql/**"
+    - component_id: think-model-sqlite
+      name: think-model-sqlite
+      paths:
+        - "packages/think-model-sqlite/**"
+    - component_id: think-mongo
+      name: think-mongo
+      paths:
+        - "packages/think-mongo/**"
+    - component_id: think-mongoose
+      name: think-mongoose
+      paths:
+        - "packages/think-mongoose/**"
+    - component_id: think-mysql
+      name: think-mysql
+      paths:
+        - "packages/think-mysql/**"
+    - component_id: think-mysql2
+      name: think-mysql2
+      paths:
+        - "packages/think-mysql2/**"
+    - component_id: think-pagination
+      name: think-pagination
+      paths:
+        - "packages/think-pagination/**"
+    - component_id: think-payload
+      name: think-payload
+      paths:
+        - "packages/think-payload/**"
+    - component_id: think-pm2
+      name: think-pm2
+      paths:
+        - "packages/think-pm2/**"
+    - component_id: think-proxy
+      name: think-proxy
+      paths:
+        - "packages/think-proxy/**"
+    - component_id: think-qs
+      name: think-qs
+      paths:
+        - "packages/think-qs/**"
+    - component_id: think-ratelimiter
+      name: think-ratelimiter
+      paths:
+        - "packages/think-ratelimiter/**"
+    - component_id: think-redis
+      name: think-redis
+      paths:
+        - "packages/think-redis/**"
+    - component_id: think-resource
+      name: think-resource
+      paths:
+        - "packages/think-resource/**"
+    - component_id: think-router
+      name: think-router
+      paths:
+        - "packages/think-router/**"
+    - component_id: think-router-rest
+      name: think-router-rest
+      paths:
+        - "packages/think-router-rest/**"
+    - component_id: think-sequelize
+      name: think-sequelize
+      paths:
+        - "packages/think-sequelize/**"
+    - component_id: think-session
+      name: think-session
+      paths:
+        - "packages/think-session/**"
+    - component_id: think-session-cookie
+      name: think-session-cookie
+      paths:
+        - "packages/think-session-cookie/**"
+    - component_id: think-session-file
+      name: think-session-file
+      paths:
+        - "packages/think-session-file/**"
+    - component_id: think-session-jwt
+      name: think-session-jwt
+      paths:
+        - "packages/think-session-jwt/**"
+    - component_id: think-session-mysql
+      name: think-session-mysql
+      paths:
+        - "packages/think-session-mysql/**"
+    - component_id: think-session-redis
+      name: think-session-redis
+      paths:
+        - "packages/think-session-redis/**"
+    - component_id: think-store-file
+      name: think-store-file
+      paths:
+        - "packages/think-store-file/**"
+    - component_id: think-svg-captcha
+      name: think-svg-captcha
+      paths:
+        - "packages/think-svg-captcha/**"
+    - component_id: think-trace
+      name: think-trace
+      paths:
+        - "packages/think-trace/**"
+    - component_id: think-typescript
+      name: think-typescript
+      paths:
+        - "packages/think-typescript/**"
+    - component_id: think-validator
+      name: think-validator
+      paths:
+        - "packages/think-validator/**"
+    - component_id: think-view
+      name: think-view
+      paths:
+        - "packages/think-view/**"
+    - component_id: think-view-ejs
+      name: think-view-ejs
+      paths:
+        - "packages/think-view-ejs/**"
+    - component_id: think-view-handlebars
+      name: think-view-handlebars
+      paths:
+        - "packages/think-view-handlebars/**"
+    - component_id: think-view-nunjucks
+      name: think-view-nunjucks
+      paths:
+        - "packages/think-view-nunjucks/**"
+    - component_id: think-view-pug
+      name: think-view-pug
+      paths:
+        - "packages/think-view-pug/**"
+    - component_id: think-watcher
+      name: think-watcher
+      paths:
+        - "packages/think-watcher/**"
+    - component_id: think-websocket
+      name: think-websocket
+      paths:
+        - "packages/think-websocket/**"
+    - component_id: think-websocket-socket.io
+      name: think-websocket-socket.io
+      paths:
+        - "packages/think-websocket-socket.io/**"
+    - component_id: think-websocket-ws
+      name: think-websocket-ws
+      paths:
+        - "packages/think-websocket-ws/**"
+    - component_id: thinkjs
+      name: thinkjs
+      paths:
+        - "packages/thinkjs/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
 coverage:
   status:
     project:
@@ -11,11 +16,12 @@ coverage:
         informational: true
 
 comment:
-  layout: "header, diff, components, files"
+  layout: "header, diff, components, files, footer"
   behavior: default
+  after_n_builds: 1
   require_changes: false
   require_base: false
-  require_head: true
+  require_head: false
   hide_project_coverage: false
 
 component_management:

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "packageManager": "pnpm@11.6.0",
   "scripts": {
     "test": "pnpm -r --if-present --filter './packages/**' --filter '!think-cache-memcache' --filter '!think-memcache' --filter '!think-mongo' test",
+    "coverage": "c8 pnpm test",
     "lint": "pnpm -r --if-present --filter './packages/**' lint"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "c8": "^12.0.0",
     "eslint": "^10.8.0",
     "globals": "^17.9.0",
     "pre-commit": "^1.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0(supports-color@7.2.0))
+      c8:
+        specifier: ^12.0.0
+        version: 12.0.0
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(supports-color@7.2.0)
@@ -2347,6 +2350,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2405,6 +2412,10 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2566,6 +2577,9 @@ packages:
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2718,6 +2732,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@2.2.1:
     resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
     engines: {node: '>=0.10.0'}
@@ -2729,6 +2747,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
@@ -3299,6 +3321,16 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  c8@12.0.0:
+    resolution: {integrity: sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
+
   cache-base@1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
@@ -3459,6 +3491,10 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -4201,6 +4237,9 @@ packages:
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -4587,6 +4626,10 @@ packages:
     resolution: {integrity: sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==}
     engines: {node: '>=0.10.0'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -4676,6 +4719,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -4740,6 +4787,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@3.2.3:
     resolution: {integrity: sha512-WPaLsMHD1lYEqAmIQI6VOJSPwuBdGShDWnj1yUo0vQqEO809R8W3LM9OVU13CnnDhyv/EiNwOtxEW74SmrzS6w==}
@@ -4984,6 +5035,9 @@ packages:
 
   html-comment-regex@1.1.2:
     resolution: {integrity: sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-minifier@3.5.21:
     resolution: {integrity: sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==}
@@ -5395,6 +5449,18 @@ packages:
     resolution: {integrity: sha512-q/16W7EPHRL0FKVz9NU++TUsoygXGj6JOi88oulyAcQG+IEZ0T6teVdE+VLbe19OfL/tbV8Wi3Dfo0HedeHW0Q==}
     engines: {node: '>=8.3'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   istanbul@0.4.0:
     resolution: {integrity: sha512-wEy53kU48MZlAAOuo9VlzOu08CnR44Xt/diX4lHSs18T1ByGvWSBrC3oPHCMPktyDwFbh9VI30q1aShEekuI4Q==}
     deprecated: |-
@@ -5748,6 +5814,10 @@ packages:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
     engines: {node: '>=0.10.0'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@2.7.3:
     resolution: {integrity: sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==}
 
@@ -5772,6 +5842,10 @@ packages:
   make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
     engines: {node: '>=4'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-iterator@1.0.1:
     resolution: {integrity: sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==}
@@ -5948,6 +6022,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
@@ -6624,6 +6702,10 @@ packages:
   path-root@0.1.1:
     resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
     engines: {node: '>=0.10.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
@@ -7398,6 +7480,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   signale@1.4.0:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
@@ -7598,6 +7684,14 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -7615,6 +7709,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -7745,6 +7843,10 @@ packages:
     resolution: {integrity: sha512-MokUp0+MFal4CmJDVL6VAO1bKegeXcBM2RnPVfqcFIp2IIv8EbPAjG0j/vEy/vuKB8NVMMSF2vfpVS/QLe4DBg==}
     engines: {node: '>=4.2.6'}
     deprecated: terraformer is deprecated and no longer supported. Please use @terraformer/arcgis.
+
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
 
   text-extensions@1.9.0:
     resolution: {integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==}
@@ -8197,6 +8299,10 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   v8flags@2.1.1:
     resolution: {integrity: sha512-SKfhk/LlaXzvtowJabLZwD4K6SGRYeoxA7KJeISlUMAB/NT4CBkZjMq3WceX2Ckm4llwqYVo8TICgsDYCBU2tA==}
     engines: {node: '>= 0.10.0'}
@@ -8336,6 +8442,10 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrap-fn@0.1.5:
     resolution: {integrity: sha512-xDLdGx0M8JQw9QDAC9s5NUxtg9MI09F6Vbxa2LYoSoCvzJnx2n81YMIfykmXEGsUvuLaxnblJTzhSOjUOX37ag==}
 
@@ -8387,6 +8497,10 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
@@ -8408,12 +8522,24 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs-parser@4.2.1:
     resolution: {integrity: sha512-+QQWqC2xeL0N5/TE+TY6OGEqyNRM+g2/r712PDNYgiCdXYCApXf1vzfmDSLBxfGRwV+moTq/V8FnMI24JCm2Yg==}
 
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yargs@3.10.0:
     resolution: {integrity: sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==}
@@ -9120,6 +9246,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(supports-color@7.2.0))':
     dependencies:
       eslint: 10.8.0(supports-color@7.2.0)
@@ -9169,6 +9297,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9427,6 +9557,8 @@ snapshots:
       '@types/minimatch': 6.0.0
       '@types/node': 8.10.66
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/keyv@3.1.4':
@@ -9581,6 +9713,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@2.2.1: {}
 
   ansi-styles@3.2.1:
@@ -9590,6 +9724,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   ansicolors@0.3.2: {}
 
@@ -10491,6 +10627,20 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  c8@12.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 18.1.0
+      yargs-parser: 21.1.1
+
   cache-base@1.0.1:
     dependencies:
       collection-visit: 1.0.0
@@ -10712,6 +10862,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clone@1.0.4: {}
 
@@ -11383,6 +11539,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emojis-list@2.1.0: {}
@@ -11852,6 +12010,11 @@ snapshots:
     dependencies:
       for-in: 1.0.2
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forever-agent@0.6.1: {}
 
   form-data@2.1.4:
@@ -11938,6 +12101,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -12020,6 +12185,12 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@3.2.3:
     dependencies:
@@ -12162,8 +12333,7 @@ snapshots:
 
   has-flag@3.0.0: {}
 
-  has-flag@4.0.0:
-    optional: true
+  has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -12298,6 +12468,8 @@ snapshots:
       depd: 2.0.0
 
   html-comment-regex@1.1.2: {}
+
+  html-escaper@2.0.2: {}
 
   html-minifier@3.5.21:
     dependencies:
@@ -12725,6 +12897,19 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   istanbul@0.4.0:
     dependencies:
       abbrev: 1.0.9
@@ -13134,6 +13319,8 @@ snapshots:
 
   lowercase-keys@1.0.1: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@2.7.3: {}
 
   lru-cache@4.1.5:
@@ -13156,6 +13343,10 @@ snapshots:
   make-dir@1.3.0:
     dependencies:
       pify: 3.0.0
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.0
 
   make-iterator@1.0.1:
     dependencies:
@@ -13376,6 +13567,8 @@ snapshots:
   minimist@1.2.0: {}
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mixin-deep@1.3.2:
     dependencies:
@@ -13985,6 +14178,11 @@ snapshots:
   path-root@0.1.1:
     dependencies:
       path-root-regex: 0.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   path-to-regexp@1.9.0:
     dependencies:
@@ -14964,6 +15162,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.1.0: {}
+
   signale@1.4.0:
     dependencies:
       chalk: 2.4.2
@@ -15221,6 +15421,17 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -15238,6 +15449,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
 
@@ -15306,7 +15521,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-    optional: true
 
   supports-hyperlinks@1.0.1:
     dependencies:
@@ -15389,6 +15603,12 @@ snapshots:
   terraformer@1.0.12:
     optionalDependencies:
       '@types/geojson': 1.0.6
+
+  test-exclude@8.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 13.0.6
+      minimatch: 10.2.5
 
   text-extensions@1.9.0: {}
 
@@ -15899,6 +16119,12 @@ snapshots:
 
   uuid@8.3.2: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   v8flags@2.1.1:
     dependencies:
       user-home: 1.1.1
@@ -16055,6 +16281,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrap-fn@0.1.5:
     dependencies:
       co: 3.1.0
@@ -16084,6 +16316,8 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  y18n@5.0.8: {}
+
   yallist@2.1.2: {}
 
   yallist@3.1.1: {}
@@ -16098,6 +16332,10 @@ snapshots:
       decamelize: 1.2.0
 
   yargs-parser@20.2.9: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs-parser@4.2.1:
     dependencies:
@@ -16116,6 +16354,15 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yargs@3.10.0:
     dependencies:


### PR DESCRIPTION
## What changed

- collect one repository-wide LCOV report with c8 on the Node.js 24 CI job
- upload only `coverage/lcov.info` to Codecov using GitHub OIDC
- configure informational project and patch coverage statuses
- define a Codecov component for every package under `packages/`
- wait for CI and the single coverage upload before posting/updating the Codecov PR comment
- show overall, diff, component, and file coverage in PR comments
- replace the stale Coveralls badges in both READMEs with Codecov badges

## Why

The existing workflow only exposes whether tests passed. It does not publish a current overall coverage percentage or make per-package coverage visible. A single LCOV upload keeps the existing pnpm workspace test flow while Codecov Components derive module-level coverage from package paths.

## Validation

- `pnpm lint`
- `pnpm coverage`
  - statements/lines: 67.23%
  - branches: 91.21%
  - functions: 79.01%
  - 250 source files across 73 JavaScript-bearing package directories
- confirmed the LCOV report excludes test files and ESLint/Webpack config files
- validated `codecov.yml` with Codecov's official validation endpoint
- parsed the workflow YAML and c8 JSON configuration locally
- GitHub Actions passed on Node.js 22, 24, and 26
- Codecov OIDC upload succeeded and reported exactly one coverage file
- Codecov project, patch, and component checks appeared on this PR
- the Codecov bot successfully posted its initial integration comment

## Rollout note

This setup PR has no Codecov report on its `master` base commit, so Codecov posts its initial welcome comment rather than a numeric comparison. Merging this PR triggers the `master` workflow and establishes the baseline; subsequent PRs will receive the configured numeric overall, diff, component, and file coverage comment after CI finishes.

Coverage statuses remain informational during the initial rollout. Once the baseline is accepted, the project and patch statuses can be made required and `fail_ci_if_error` can be enabled.