### PR TITLE
fix think-helper CommonJS UUID generation

### DIFF
--- a/packages/think-helper/index.js
+++ b/packages/think-helper/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const crypto = require('crypto');
 const net = require('net');
 const cluster = require('cluster');
-const uuid = require('uuid');
+const UUID = require('pure-uuid');
 const ms = require('ms');
 const {
   isArray,
@@ -270,8 +270,8 @@ exports.datetime = datetime;
  * @return {String}         []
  */
 exports.uuid = function(version) {
-  if (version === 'v1') return uuid.v1();
-  return uuid.v4();
+  if (version === 'v1') return new UUID(1).format();
+  return crypto.randomUUID();
 };
 
 /**

--- a/packages/think-helper/package.json
+++ b/packages/think-helper/package.json
@@ -24,7 +24,7 @@
     "core-util-is": "^1.0.3",
     "lodash.merge": "^4.6.2",
     "ms": "^2.1.3",
-    "uuid": "^14.0.1"
+    "pure-uuid": "^2.0.0"
   },
   "devDependencies": {
     "codecov": "^3.8.3",

--- a/packages/think-helper/test/index.js
+++ b/packages/think-helper/test/index.js
@@ -253,10 +253,11 @@ test('rmdir 2', async(t) => {
 });
 
 test('uuid', t => {
-  var uuid1 = uuid('v1');
-  t.assert.strictEqual(uuid1.length > 1, true);
-  var uuid2 = uuid();
-  t.assert.strictEqual(uuid2.length > 1, true);
+  const uuid1 = uuid('v1');
+  t.assert.match(uuid1, /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+
+  const uuid2 = uuid();
+  t.assert.match(uuid2, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
 });
 
 test('ms 1200', t => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,9 +448,9 @@ importers:
       ms:
         specifier: ^2.1.3
         version: 2.1.3
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
+      pure-uuid:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       codecov:
         specifier: ^3.8.3
@@ -7030,6 +7030,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-uuid@2.0.0:
+    resolution: {integrity: sha512-xJzjKStYxaGLtRcrTObZx0XE63h+pdTxqrLZaPtpeIn/fKllOeOkYrAwKjpLMlEr+/dFMFHfDDxTElVn6Sb/Gg==}
+    engines: {node: '>=8.0.0'}
+
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
@@ -8279,10 +8283,6 @@ packages:
   utility@1.18.0:
     resolution: {integrity: sha512-PYxZDA+6QtvRvm//++aGdmKG/cI07jNwbROz0Ql+VzFV1+Z0Dy55NI4zZ7RHc9KKpBePNFwoErqIuqQv/cjiTA==}
     engines: {node: '>= 0.12.0'}
-
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
-    hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
@@ -14606,6 +14606,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-uuid@2.0.0: {}
+
   q@1.5.1: {}
 
   qs@6.15.2:
@@ -16110,8 +16112,6 @@ snapshots:
       mkdirp: 0.5.6
       mz: 2.7.0
       unescape: 1.0.1
-
-  uuid@14.0.1: {}
 
   uuid@3.4.0: {}
 


### PR DESCRIPTION
## What changed

- replace the ESM-only `uuid` dependency in `think-helper` with `pure-uuid`
- generate UUID v4 values with Node.js `crypto.randomUUID()`
- preserve UUID v1 support through `pure-uuid`
- strengthen tests to validate UUID version and variant bits

## Why

`think-helper` is a CommonJS package and loads dependencies with `require()`. `uuid@14` only exports ES modules, so requiring `think-helper` fails before any helper can be used.

Using Node's built-in UUID generator for v4 removes the unnecessary dependency for the common path, while `pure-uuid` preserves the existing `uuid('v1')` API.

## Impact

The public `uuid(version?)` API remains unchanged:

- `uuid('v1')` returns a version 1 UUID
- `uuid()` and other version values return a version 4 UUID

## Validation

- `pnpm --filter think-helper test`
- 77 tests passed
- `git diff --check`